### PR TITLE
Store postgres credentials in pgpass

### DIFF
--- a/signal_emulator/resources/configs/signal_emulator_from_files_config.json
+++ b/signal_emulator/resources/configs/signal_emulator_from_files_config.json
@@ -3,7 +3,7 @@
         "host": "localhost",
         "database": "tfl_signal_timings",
         "user": "postgres",
-        "port": 5433,
+        "port": 5432,
         "schema": "v1"
     },
     "load_from_postgres": false,

--- a/signal_emulator/resources/configs/signal_emulator_from_files_config.json
+++ b/signal_emulator/resources/configs/signal_emulator_from_files_config.json
@@ -3,8 +3,7 @@
         "host": "localhost",
         "database": "tfl_signal_timings",
         "user": "postgres",
-        "password": "password",
-        "port": "5433",
+        "port": 5433,
         "schema": "v1"
     },
     "load_from_postgres": false,

--- a/signal_emulator/resources/configs/signal_emulator_from_pg_config.json
+++ b/signal_emulator/resources/configs/signal_emulator_from_pg_config.json
@@ -3,8 +3,7 @@
         "host": "localhost",
         "database": "tfl_signal_timings",
         "user": "postgres",
-        "password": "password",
-        "port": "5433",
+        "port": 5433,
         "schema": "v1"
     },
     "load_from_postgres": true,

--- a/signal_emulator/resources/configs/signal_emulator_from_pg_config.json
+++ b/signal_emulator/resources/configs/signal_emulator_from_pg_config.json
@@ -3,7 +3,7 @@
         "host": "localhost",
         "database": "tfl_signal_timings",
         "user": "postgres",
-        "port": 5433,
+        "port": 5432,
         "schema": "v1"
     },
     "load_from_postgres": true,

--- a/signal_emulator/utilities/postgres_connection.py
+++ b/signal_emulator/utilities/postgres_connection.py
@@ -1,19 +1,26 @@
 import psycopg2
 import pandas as pd
 from sqlalchemy import create_engine
+from psycopg2 import OperationalError
 
 
 class PostgresConnection:
-    def __init__(self, host, database, user, password, port, schema=None):
+    def __init__(self, host, database, user, port, schema=None):
         self.host = host
         self.database = database
         self.user = user
-        self.password = password
         self.port = port
         self.schema = schema
-        self.conn = psycopg2.connect(
-            host=host, database=database, user=user, password=password, port=port
-        )
+        try:
+            self.conn = psycopg2.connect(
+                host=host, database=database, user=user, port=port
+            )
+        except OperationalError as e:
+            raise OperationalError(
+                f"{e}"
+                f"Windows users: Postgres credentials pgpass should be stored in "
+                "$USERPROFILE/AppData/Roaming/postgresql/pgpass.conf"
+            )
         self.engine = create_engine(self.connection_uri)
 
     def __repr__(self):
@@ -21,7 +28,7 @@ class PostgresConnection:
 
     @property
     def connection_uri(self):
-        return f"postgresql+psycopg2://{self.user}:{self.password}@{self.host}:{self.port}/{self.database}"
+        return f"postgresql+psycopg2://{self.user}@{self.host}:{self.port}/{self.database}"
 
     def read_table_from_df(self, schema, table):
         return pd.read_sql_query(f"SELECT * FROM {schema}.{table}", self.engine)

--- a/signal_emulator/utilities/postgres_connection.py
+++ b/signal_emulator/utilities/postgres_connection.py
@@ -13,13 +13,13 @@ class PostgresConnection:
         self.schema = schema
         try:
             self.conn = psycopg2.connect(
-                host=host, database=database, user=user, port=port
+                host=host, port=port, database=database, user=user
             )
         except OperationalError as e:
             raise OperationalError(
                 f"{e}"
                 f"Windows users: Postgres credentials pgpass should be stored in "
-                "$USERPROFILE/AppData/Roaming/postgresql/pgpass.conf"
+                "%APPDATA%/Roaming/postgresql/pgpass.conf"
             )
         self.engine = create_engine(self.connection_uri)
 


### PR DESCRIPTION
PR remove postgres credentials from being exposed in the codebase, and moved to a pgpass.conf file

Windows users need to store postgres credentials in $USERPROFILE/AppData/Roaming/postgresql/pgpass.conf"

pgpass.conf
<host>:<port>:<database_name>:<user>:<password>
